### PR TITLE
added set -euo pipefail

### DIFF
--- a/sh/install.sh
+++ b/sh/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 INSTALL_LOG=`mktemp /tmp/install_wavefront_XXXXXXXXXX.log`
 
 function check_if_root_or_die() {


### PR DESCRIPTION
In some automated environments, errors can get gobbled up when the script is run.  This will ensure they bubble up properly.

See: https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/