### PR TITLE
INT-797: Added user permission check for telegraf config path

### DIFF
--- a/wavefront_cli/__init__.py
+++ b/wavefront_cli/__init__.py
@@ -1,2 +1,2 @@
 """Initialize wavefront cli version."""
-__version__ = '0.0.121'
+__version__ = '0.0.122'

--- a/wavefront_cli/commands/install.py
+++ b/wavefront_cli/commands/install.py
@@ -182,6 +182,8 @@ class Install(Base):  # pylint: disable=too-few-public-methods
                         os.chown(os.path.join(root, name), uid, -1)
                     for name in files:
                         os.chown(os.path.join(root, name), uid, -1)
+            # The static sleep is added for `os.chown` to change owner of
+            # telegraf sub-directories and files
             time.sleep(5)
 
             lib.system.restart_service(agent_name)

--- a/wavefront_cli/commands/install.py
+++ b/wavefront_cli/commands/install.py
@@ -2,9 +2,9 @@
 
 from __future__ import print_function
 
-import sys
-import pwd
 import os
+import pwd
+import sys
 import time
 
 from wavefront_cli import lib
@@ -170,8 +170,8 @@ class Install(Base):  # pylint: disable=too-few-public-methods
                 if not lib.agent.tag_telegraf_config('cli user tags', tags):
                     sys.exit(1)
 
-            # check if user 'telegraf' has read permission for config path
-            # if not change owner of telegraf path to 'telegraf' user recursively
+            # check if user 'telegraf' has read permission for config path if
+            # not change owner of telegraf path to 'telegraf' user recursively
             uid = pwd.getpwnam(agent_name).pw_uid
             path = '/etc/telegraf'
 

--- a/wavefront_cli/commands/install.py
+++ b/wavefront_cli/commands/install.py
@@ -4,9 +4,7 @@ from __future__ import print_function
 
 import sys
 import pwd
-import grp
 import os
-import stat
 import time
 
 from wavefront_cli import lib
@@ -174,7 +172,7 @@ class Install(Base):  # pylint: disable=too-few-public-methods
 
             # check if user 'telegraf' has read permission for config path
             # if not change owner of telegraf path to 'telegraf' user recursively
-            uid = pwd.getpwnam("telegraf").pw_uid
+            uid = pwd.getpwnam(agent_name).pw_uid
             path = '/etc/telegraf'
 
             if not uid == os.stat(path).st_uid:


### PR DESCRIPTION
Added user permission check to confirm whether the `telegraf` user has read permission to config path `/etc/telegraf`. If no permission then the script assigns read access to the config path.