### PR TITLE
Add Python 3.9 and Remove EOLed 3.5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 dist: bionic
 language: python
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 install:
   - pip install flake8 flake8-colors flake8-import-order
   - pip install pep8-naming

--- a/wavefront_cli/__init__.py
+++ b/wavefront_cli/__init__.py
@@ -1,2 +1,2 @@
 """Initialize wavefront cli version."""
-__version__ = '0.0.122'
+__version__ = '0.0.123'


### PR DESCRIPTION
Python 3.5 has reached end-of-life and is now retired.
https://python.org/dev/peps/pep-0478/#id4