### PR TITLE
chore: remove README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,0 @@
-wavefront-cli
-=========================
-.. image:: https://travis-ci.com/wavefrontHQ/wavefront-cli.svg?branch=master
-    :target: https://travis-ci.com/wavefrontHQ/wavefront-cli
-
-The Wavefront Integration Command Line Interface (CLI) is a utility for installing and configuring the Wavefront proxy, Telegraf collector agent, and integrations.
-


### PR DESCRIPTION
Having a README.md and a README.rst seems confusing, and the README.md has more in it than the README.rst